### PR TITLE
Update UnicodeConverter.pyw

### DIFF
--- a/tools/UnicodeConverter.pyw
+++ b/tools/UnicodeConverter.pyw
@@ -25,7 +25,10 @@ if not hasattr(sys, "frozen"):                                  ## Check if not 
     datafile = os.path.join(os.path.dirname(__file__), datafile)## Use icon file reside in same directory as script
 else:                                                           ## But if it is running from exe
     datafile = os.path.join(sys.prefix, datafile)               ## Use icon file from the temporary system directory
-root.iconbitmap(default=datafile)                               ## Declare the small icon shown on window
+try:
+    root.iconbitmap(default=datafile)                               ## Declare the small icon shown on window
+except:
+    pass
 
 ##[1]---------------Declare the frames inside container
 TopMainFrame = Frame(root, width=450, height=7, bg="grey", bd=8)


### PR DESCRIPTION
On Linux, using Python 2.7.15rc1, I get the following error message:

```
  File "UnicodeConverter.pyw", line 29, in <module>
    root.iconbitmap(default=datafile)                               ## Declare the small icon shown on window
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1699, in wm_iconbitmap
    return self.tk.call('wm', 'iconbitmap', self._w, '-default', default)
_tkinter.TclError: wrong # args: should be "wm iconbitmap window ?bitmap?"
```

I am not sure what the root cause is but just catching (and ignoring) exceptions on `root.iconbitmap(default=datafile)` allows the program to run